### PR TITLE
Add finance/manager Daily Ops MVP with stable week close and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,23 @@ docker run -p 8080:80 real-state-app
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
+
+## Finance/Manager Daily Ops MVP
+
+### Backend (FastAPI)
+
+New API app under `backend/app`:
+
+- `POST /ops/daily-run`: runs CSV sync for each source configured in `CSV_SOURCES` (comma-separated).
+- `POST /weeks/{weekStart}/close`: closes week once and persists `WeekClosure` + `WeekAgentSnapshot`.
+- `GET /weeks/{weekStart}/export`: exports week snapshots as CSV.
+
+Use role header `X-Role: finance` or `X-Role: manager`.
+
+### Frontend (React)
+
+New Ops UI under `frontend/src`:
+
+- `/ops` route with **Run Daily Sync** button.
+- **Close week** button with `confirm()`.
+- Export CSV link for selected week.

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,9 @@
+from fastapi import Header, HTTPException
+
+ALLOWED_ROLES = {"finance", "manager"}
+
+
+def require_finance_or_manager(x_role: str = Header(default="", alias="X-Role")):
+    if x_role not in ALLOWED_ROLES:
+        raise HTTPException(status_code=403, detail="Only finance/manager can access this endpoint")
+    return x_role

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./ops.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,112 @@
+import csv
+import io
+import os
+from datetime import date
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .auth import require_finance_or_manager
+from .db import Base, engine, get_db
+from .models import Sale, WeekAgentSnapshot, WeekClosure
+from .sync import run_csv_sync
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Daily Ops MVP")
+
+
+def _sources() -> list[str]:
+    raw = os.getenv("CSV_SOURCES", "")
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+@app.post("/ops/daily-run", dependencies=[Depends(require_finance_or_manager)])
+def daily_run(db: Session = Depends(get_db)):
+    results = []
+    for source in _sources():
+        try:
+            results.append(run_csv_sync(source, db))
+        except Exception as exc:
+            results.append(
+                {
+                    "source": source,
+                    "processed_new_rows": 0,
+                    "inserted_sales": 0,
+                    "duplicates_marked": 0,
+                    "skipped_rows": 0,
+                    "last_row_synced": 0,
+                    "error": str(exc),
+                }
+            )
+    return {"sources": results}
+
+
+@app.post("/weeks/{weekStart}/close", dependencies=[Depends(require_finance_or_manager)])
+def close_week(weekStart: date, db: Session = Depends(get_db)):
+    existing = db.query(WeekClosure).filter(WeekClosure.week_start == weekStart).first()
+    if existing:
+        raise HTTPException(status_code=409, detail=f"Week {weekStart.isoformat()} is already closed")
+
+    db.add(WeekClosure(week_start=weekStart))
+
+    aggregates = (
+        db.query(
+            Sale.agent_name,
+            Sale.company_name,
+            func.count(Sale.id).label("sales_count"),
+            func.coalesce(func.sum(Sale.commission), 0.0).label("commission_amount"),
+        )
+        .filter(Sale.week_start == weekStart)
+        .group_by(Sale.agent_name, Sale.company_name)
+        .all()
+    )
+
+    db.query(WeekAgentSnapshot).filter(WeekAgentSnapshot.week_start == weekStart).delete()
+    for row in aggregates:
+        db.add(
+            WeekAgentSnapshot(
+                week_start=weekStart,
+                agent_name=row.agent_name,
+                company_name=row.company_name,
+                sales_count=row.sales_count,
+                commission_amount=float(row.commission_amount or 0),
+            )
+        )
+
+    db.commit()
+    return {"weekStart": weekStart.isoformat(), "closed": True, "snapshots": len(aggregates)}
+
+
+@app.get("/weeks/{weekStart}/export", dependencies=[Depends(require_finance_or_manager)])
+def export_week(weekStart: date, db: Session = Depends(get_db)):
+    snapshots = (
+        db.query(WeekAgentSnapshot)
+        .filter(WeekAgentSnapshot.week_start == weekStart)
+        .order_by(WeekAgentSnapshot.agent_name.asc())
+        .all()
+    )
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["weekStart", "agentName", "companyName", "salesCount", "commission"])
+
+    for snapshot in snapshots:
+        writer.writerow(
+            [
+                snapshot.week_start.isoformat(),
+                snapshot.agent_name,
+                snapshot.company_name,
+                snapshot.sales_count,
+                snapshot.commission_amount,
+            ]
+        )
+
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="week-{weekStart.isoformat()}.csv"'},
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, Date, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from .db import Base
+
+
+class Sale(Base):
+    __tablename__ = "sales"
+
+    id = Column(Integer, primary_key=True, index=True)
+    source = Column(String, nullable=False, index=True)
+    row_hash = Column(String, nullable=False, index=True)
+    sale_date = Column(Date, nullable=False, index=True)
+    week_start = Column(Date, nullable=False, index=True)
+    agent_name = Column(String, nullable=False, index=True)
+    company_name = Column(String, nullable=False, index=True)
+    commission = Column(Float, nullable=False)
+
+    __table_args__ = (UniqueConstraint("source", "row_hash", name="uq_sale_source_rowhash"),)
+
+
+class WeekClosure(Base):
+    __tablename__ = "week_closures"
+
+    id = Column(Integer, primary_key=True, index=True)
+    week_start = Column(Date, nullable=False, unique=True, index=True)
+    closed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class WeekAgentSnapshot(Base):
+    __tablename__ = "week_agent_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    week_start = Column(Date, nullable=False, index=True)
+    agent_name = Column(String, nullable=False, index=True)
+    company_name = Column(String, nullable=False, index=True)
+    sales_count = Column(Integer, nullable=False)
+    commission_amount = Column(Float, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class SourceSyncSummary(BaseModel):
+    source: str
+    processed_new_rows: int = 0
+    inserted_sales: int = 0
+    duplicates_marked: int = 0
+    skipped_rows: int = 0
+    last_row_synced: int = 0
+    error: str | None = None

--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -1,0 +1,76 @@
+import csv
+import hashlib
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from .models import Sale
+
+
+def _week_start(dt: date) -> date:
+    return dt - timedelta(days=dt.weekday())
+
+
+def _row_hash(row: dict) -> str:
+    normalized = json.dumps(row, sort_keys=True, default=str)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def sync_sales_from_csv(source: str, db: Session) -> dict:
+    summary = {
+        "source": source,
+        "processed_new_rows": 0,
+        "inserted_sales": 0,
+        "duplicates_marked": 0,
+        "skipped_rows": 0,
+        "last_row_synced": 0,
+    }
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"CSV source not found: {source}")
+
+    with path.open("r", encoding="utf-8", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        for row_number, row in enumerate(reader, start=1):
+            summary["last_row_synced"] = row_number
+
+            try:
+                sale_date = datetime.strptime((row.get("date") or "").strip(), "%Y-%m-%d").date()
+                agent_name = (row.get("agentName") or "").strip()
+                company_name = (row.get("companyName") or "").strip()
+                commission = float(row.get("commission") or 0)
+                if not agent_name or not company_name:
+                    raise ValueError("agentName/companyName are required")
+            except Exception:
+                summary["skipped_rows"] += 1
+                continue
+
+            row_hash = _row_hash(row)
+            duplicate = db.query(Sale).filter(Sale.source == source, Sale.row_hash == row_hash).first()
+            if duplicate:
+                summary["duplicates_marked"] += 1
+                continue
+
+            summary["processed_new_rows"] += 1
+            db.add(
+                Sale(
+                    source=source,
+                    row_hash=row_hash,
+                    sale_date=sale_date,
+                    week_start=_week_start(sale_date),
+                    agent_name=agent_name,
+                    company_name=company_name,
+                    commission=commission,
+                )
+            )
+            summary["inserted_sales"] += 1
+
+    db.commit()
+    return summary
+
+
+def run_csv_sync(source: str, db: Session) -> dict:
+    return sync_sales_from_csv(source, db)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+sqlalchemy==2.0.43

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+import OpsPage from "./OpsPage";
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <nav>
+        <Link to="/ops">Daily Ops</Link>
+      </nav>
+      <Routes>
+        <Route path="/ops" element={<OpsPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/OpsPage.jsx
+++ b/frontend/src/OpsPage.jsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+
+const canManage = ["finance", "manager"].includes(localStorage.getItem("role") || "");
+
+export default function OpsPage() {
+  const [running, setRunning] = useState(false);
+  const [closeLoading, setCloseLoading] = useState(false);
+  const [weekStart, setWeekStart] = useState("");
+  const [results, setResults] = useState([]);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [weekClosed, setWeekClosed] = useState(false);
+
+  const role = localStorage.getItem("role") || "";
+
+  const runDailySync = async () => {
+    setRunning(true);
+    setError("");
+    setSuccess("");
+    try {
+      const res = await fetch("/ops/daily-run", {
+        method: "POST",
+        headers: { "X-Role": role },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.detail || "Daily sync failed");
+      setResults(data.sources || []);
+      setSuccess("Daily sync finished");
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const closeWeek = async () => {
+    if (!weekStart) return;
+    if (!window.confirm(`Close week ${weekStart}?`)) return;
+    setCloseLoading(true);
+    setError("");
+    setSuccess("");
+    try {
+      const res = await fetch(`/weeks/${weekStart}/close`, {
+        method: "POST",
+        headers: { "X-Role": role },
+      });
+      const data = await res.json();
+      if (res.status === 409) {
+        setWeekClosed(true);
+        throw new Error(data.detail);
+      }
+      if (!res.ok) throw new Error(data.detail || "Close week failed");
+      setWeekClosed(true);
+      setSuccess("Week closed successfully");
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setCloseLoading(false);
+    }
+  };
+
+  if (!canManage) return <p>Only finance/manager can access Daily Ops.</p>;
+
+  return (
+    <section>
+      <h2>Daily Ops</h2>
+
+      <button onClick={runDailySync} disabled={running}>
+        {running ? "Running..." : "Run Daily Sync"}
+      </button>
+
+      <div style={{ marginTop: 16 }}>
+        <input
+          type="date"
+          value={weekStart}
+          onChange={(e) => setWeekStart(e.target.value)}
+        />
+        <button onClick={closeWeek} disabled={closeLoading || weekClosed || !weekStart}>
+          {closeLoading ? "Closing..." : "Close week"}
+        </button>
+        {weekClosed && <small> Week already closed.</small>}
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <a href={weekStart ? `/weeks/${weekStart}/export` : "#"}>Export CSV</a>
+      </div>
+
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      {success && <p style={{ color: "green" }}>{success}</p>}
+
+      <table style={{ marginTop: 16 }}>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Processed</th>
+            <th>Inserted</th>
+            <th>Duplicates</th>
+            <th>Skipped</th>
+            <th>Last row</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((r) => (
+            <tr key={r.source}>
+              <td>{r.source}</td>
+              <td>{r.processed_new_rows}</td>
+              <td>{r.inserted_sales}</td>
+              <td>{r.duplicates_marked}</td>
+              <td>{r.skipped_rows}</td>
+              <td>{r.last_row_synced}</td>
+              <td>{r.error || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal, stable Finance/Manager operational flow to run CSV syncs, close weeks, and export week snapshots without large refactors. 
- Ship a tiny UI so `finance/manager` users can run the daily sync and perform the week-close/export flow from the app.

### Description

- Added a new FastAPI backend under `backend/app` with role-guarding via `X-Role` and a SQLite `ops.db` (`db.py`, `models.py`, `auth.py`).
- Implemented CSV sync helpers in `sync.py` (`run_csv_sync` / `sync_sales_from_csv`) that deduplicate by row hash and return per-source summaries (`processed_new_rows`, `inserted_sales`, `duplicates_marked`, `skipped_rows`, `last_row_synced`).
- Exposed endpoints in `main.py`: `POST /ops/daily-run` (runs each configured CSV source and continues on per-source errors), `POST /weeks/{weekStart}/close` (returns `409` if already closed and writes `WeekClosure` + `WeekAgentSnapshot` aggregates), and `GET /weeks/{weekStart}/export` (CSV export with columns `weekStart, agentName, companyName, salesCount, commission`).
- Added a minimal React Ops UI under `frontend/src` with `/ops` route, `OpsPage.jsx` including `Run Daily Sync`, `Close week` with `confirm()` and disabled state, and an `Export CSV` link, and updated `README.md` with usage notes.
- Added `backend/requirements.txt` listing `fastapi`, `uvicorn`, and `sqlalchemy` for running the backend.

### Testing

- Successfully compiled Python sources with `python -m py_compile backend/app/*.py` (✅).
- Attempted FastAPI runtime test using `fastapi.testclient` but it failed in this environment due to missing `fastapi` (`ModuleNotFoundError: No module named 'fastapi'`) (❌).
- Attempted to capture a frontend screenshot with Playwright at `http://localhost:3000/ops` but it failed because no frontend dev server was running (❌).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e5964954832280291f38f0a0e5a4)